### PR TITLE
Created Climesync config file

### DIFF
--- a/climesync.py
+++ b/climesync.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 
 import pymesync
+import os
 import sys
+import stat
+import re
 import argparse
 
 menu_options = (
@@ -34,10 +37,84 @@ menu_options = (
     "h - print this menu\n"
     "q - exit\n")
 
-arg_username = ""
-arg_password = ""
-timesync_url = ""
 ts = None  # pymesync.TimeSync object
+
+
+def validate_config(path="~/.climesyncrc"):
+    """Ensure that the configuration file is formatted correctly"""
+
+    realpath = os.path.expanduser(path)
+
+    # Check that the file exists. Using a non-file object is non permitted.
+    if not os.path.isfile(realpath):
+        return False
+
+    # A pound sign followed by any number of characters
+    comment = re.compile("#.*")
+
+    # Key name, equals sign, value
+    # Keys and values can consist of any character except an equals sign
+    config = re.compile("[^=]+ = [^=]+")
+
+    with open(realpath, "r") as f:
+        for index, line in enumerate(f):
+            # If a line isn't either a comment or a valid key/value pair
+            if not comment.match(line) and not config.match(line):
+                print "Error in config file on line {}".format(index)
+                print line
+
+                return False
+
+    return True
+
+
+def read_config(path="~/.climesyncrc"):
+    """Read the configuration file and return its contents"""
+
+    realpath = os.path.expanduser(path)
+
+    config_dict = dict()
+
+    # Make sure that the config file is free of errors
+    if not validate_config(realpath):
+        return config_dict  # Empty dictionary
+
+    with open(realpath, "r") as f:
+        for line in f:
+            # Ignore comments (lines beginning with '#')
+            if line.strip()[0] == "#":
+                continue
+
+            # Unpack line into a key/value pair
+            (key, value) = (s.strip() for s in line.split("="))
+            config_dict[key] = value
+
+    return config_dict
+
+
+def write_config(key, value, path="~/.climesyncrc"):
+    """Write a value to the configuration file"""
+
+    realpath = os.path.expanduser(path)
+
+    config_dict = read_config(realpath)
+
+    # Truncate existing file or create it if it doesn't exist
+    with open(realpath, "w") as f:
+        f.write("# Climesync configuration file\n")
+
+        for k, v in config_dict.iteritems():
+            # Write everything but the newly supplied key/value pair
+            if k != key:
+                f.write("{} = {}\n".format(k, v))
+
+        # Write the new key/value pair
+        f.write("{} = {}\n".format(key, value))
+
+    # Set permissions if writing to a new file
+    if not config_dict:
+        # Owner has read/write permission
+        os.chmod(realpath, stat.S_IRUSR | stat.S_IWUSR)
 
 
 def print_json(response):
@@ -170,6 +247,22 @@ def get_fields(fields):
     return responses
 
 
+def add_kv_pair(key, value, path="~/.climesyncrc"):
+    """Ask the user if they want to add a key/value pair to the config file"""
+
+    config_dict = read_config(path)
+
+    # If that key/value pair is already in the config, skip asking
+    if key in config_dict and config_dict[key] == value:
+        return
+
+    print "{} = {}".format(key, value)
+    response = get_field("Add to the config file?", field_type="?")
+
+    if response:
+        write_config(key, value, path)
+
+
 def get_user_permissions(users):
     """Asks for permissions for multiple users and returns them in a dict"""
 
@@ -194,16 +287,30 @@ def get_user_permissions(users):
     return permissions
 
 
-def connect(test=False):
+def connect(arg_url="", config_dict=dict(), test=False):
     """Creates a new pymesync.TimeSync instance with a new URL"""
 
-    global timesync_url, ts
+    global ts
 
-    # Set the global variable so we can reconnect later
-    timesync_url = raw_input("URL of TimeSync server: ") if not test else "tst"
+    url = ""
+
+    # Set the global variable so we can reconnect later.
+    # If the URL is in the config, use that value at program startup
+    # If the URL is provided in command line arguments, use that value
+    if arg_url:
+        url = arg_url
+
+    elif "TIMESYNC_URL" in config_dict:
+        url = config_dict["TIMESYNC_URL"]
+
+    else:
+        url = raw_input("URL of TimeSync server: ") if not test else "tst"
+
+    if not test:
+        add_kv_pair("TIMESYNC_URL", url)
 
     # Create a new instance and attempt to connect to the provided url
-    ts = pymesync.TimeSync(baseurl=timesync_url, test=test)
+    ts = pymesync.TimeSync(baseurl=url, test=test)
 
     # No response from server upon connection
     return list()
@@ -220,17 +327,38 @@ def disconnect():
     return list()
 
 
-def sign_in():
+def sign_in(arg_user="", arg_pass="", config_dict=dict()):
     """Attempts to sign in with user-supplied or command line credentials"""
 
-    global arg_username, arg_password, ts
+    global ts
 
     if not ts:
         return {"error": "Not connected to TimeSync server"}
 
-    # If username or password not provided on command line, ask for them
-    username = arg_username if arg_username else raw_input("Username: ")
-    password = arg_password if arg_password else raw_input("Password: ")
+    username = ""
+    password = ""
+
+    # If username or password in config, use them at program startup.
+    if arg_user:
+        username = arg_user
+
+    elif "USERNAME" in config_dict:
+        username = config_dict["USERNAME"]
+
+    else:
+        username = raw_input("Username: ")
+
+    if arg_pass:
+        password = arg_pass
+
+    elif "PASSWORD" in config_dict:
+        password = config_dict["PASSWORD"]
+
+    else:
+        password = raw_input("Password: ")
+
+    add_kv_pair("USERNAME", username)
+    add_kv_pair("PASSWORD", password)
 
     # Attempt to authenticate and return the server's response
     return ts.authenticate(username, password, "password")
@@ -239,16 +367,16 @@ def sign_in():
 def sign_out():
     """Signs out from TimeSync and resets command line credentials"""
 
-    global arg_username, arg_password, timesync_url, ts
+    global ts
 
     if not ts:
         return {"error": "Not connected to TimeSync server"}
 
-    # Reset the credentials provided on the command line
-    arg_username = arg_password = ""
+    url = ts.baseurl
+    test = ts.test
 
     # Create a new instance connected to the same server as the last
-    ts = pymesync.TimeSync(baseurl=timesync_url)
+    ts = pymesync.TimeSync(baseurl=url, test=test)
 
     # No response from server
     return list()
@@ -702,8 +830,6 @@ def menu():
 
 
 def main():
-    global arg_username, arg_password, timesync_url, ts
-
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--connect", help="connect to a timesync server")
     parser.add_argument("-u", "--username", help="specify your username")
@@ -711,22 +837,18 @@ def main():
 
     # Command line arguments
     args = parser.parse_args()
+    url = args.connect
+    user = args.username
+    password = args.password
 
-    if args.connect:
-        timesync_url = args.connect
+    # Config file
+    config = read_config()
 
-        # Attempt to connect with the provided URL
-        ts = pymesync.TimeSync(baseurl=timesync_url)
+    # Attempt to connect with arguments and/or config
+    connect(arg_url=url, config_dict=config)
 
-    if args.username:
-        arg_username = args.username
-
-    if args.password:
-        arg_password = args.password
-
-    # If all args are provided, attempt to sign in
-    if timesync_url and arg_username and arg_password:
-        print_json(sign_in())
+    response = sign_in(arg_user=user, arg_pass=password, config_dict=config)
+    print_json(response)
 
     while True:
         menu()

--- a/climesync.py
+++ b/climesync.py
@@ -357,8 +357,9 @@ def sign_in(arg_user="", arg_pass="", config_dict=dict()):
     else:
         password = raw_input("Password: ")
 
-    add_kv_pair("USERNAME", username)
-    add_kv_pair("PASSWORD", password)
+    if not ts.test:
+        add_kv_pair("USERNAME", username)
+        add_kv_pair("PASSWORD", password)
 
     # Attempt to authenticate and return the server's response
     return ts.authenticate(username, password, "password")

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -45,6 +45,12 @@ Climesync also accepts several optional command line arguments
 -u <username>, --user <username>      Attempt to authenticate on startup with the given username
 -p <password>, --password <password>  Attempt to authenticate on startup with the given password
 
+Since server information and user credentials can be specified in multiple
+places (See `Climesync Configuration`_ below), these values are prioritized
+in the following order:
+
+**User input inside program > Command line arguments > Configuration file values**
+
 Climesync Options
 -----------------
 
@@ -116,3 +122,21 @@ Admin-only options:
 
     **du**
         Delete a user
+
+Climesync Configuration
+-----------------------
+
+On the first run of the program, the configuration file .climesyncrc is
+created in the user's home directory. This configuration file stores server
+information and user credentials. Editing this file manually should not be
+necessary because Climesync updates these values as necessary
+
+The following configuration values are stored in .climesyncrc:
+
+============ =======================================================
+    Key                            Description
+============ =======================================================
+TIMESYNC_URL The URL of the TimeSync server to connect to on startup
+USERNAME     The username of the user to authenticate as on startup
+PASSWORD     The password of the user to authenticate as on startup
+============ =======================================================

--- a/testing/climesync_test.py
+++ b/testing/climesync_test.py
@@ -1,11 +1,16 @@
 import unittest
+import os
 import climesync
 
 
 class ClimesyncTest(unittest.TestCase):
 
     def setUp(self):
-        climesync.connect(test=True)
+        self.config = { "TIMESYNC_URL": "test",
+                        "USERNAME":     "test",
+                        "PASSWORD":     "test" }
+
+        climesync.connect(config_dict=self.config, test=True)
 
     def tearDown(self):
         climesync.disconnect()
@@ -19,13 +24,15 @@ class ClimesyncTest(unittest.TestCase):
         self.assertIsNone(climesync.ts)
 
     def test_sign_in(self):
-        climesync.arg_username = "test-user"
-        climesync.arg_password = "test-pass"
-
         climesync.disconnect()
-        response = climesync.sign_in()
+        response = climesync.sign_in(config_dict=self.config)
         self.assertIn("error", response)
 
-        climesync.connect(test=True)
-        response = climesync.sign_in()
+        climesync.connect(config_dict=self.config, test=True)
+        response = climesync.sign_in(config_dict=self.config)
         self.assertEqual(response["token"], "TESTTOKEN")
+
+    def test_validate_config(self):
+        config_valid = climesync.validate_config(os.devnull)
+
+        self.assertEqual(config_valid, False)

--- a/testing/climesync_test.py
+++ b/testing/climesync_test.py
@@ -6,9 +6,9 @@ import climesync
 class ClimesyncTest(unittest.TestCase):
 
     def setUp(self):
-        self.config = { "TIMESYNC_URL": "test",
-                        "USERNAME":     "test",
-                        "PASSWORD":     "test" }
+        self.config = {"TIMESYNC_URL": "test",
+                       "USERNAME":     "test",
+                       "PASSWORD":     "test"}
 
         climesync.connect(config_dict=self.config, test=True)
 


### PR DESCRIPTION
Climesync now uses a config file (~/.climesyncrc) to store server url, username, and password information. At the current time, this information is only protected by user permissions (chmod 600). 

When the program first starts, arguments passed in through the command line take highest precedence followed by values stored in the configuration file. When users enter new server or user information while using the program, they are prompted by the program to ask if they want to store the new information in the config file.

In addition, the way that the program handles command line arguments in general has been cleaned up and clarified.