### PR TITLE
Remove non-official warning and add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--
+  This is a guideline for what a PR should look like.
+  Feel free to modify it to fit your specific needs.
+
+  Please list the issue this fixes in the PR
+-->
+fixes issue #xx
+
+## Changes in this PR.
+<!--
+  Please include a list of all things this PR will accomplish
+  Use the checkbox syntax to show what is done and what is yet to be completed.
+  This gives context to the diff.
+-->
+
+- [X] Foo
+- [X] Bar
+- [ ] Baz
+
+## Testing this PR.
+<!--
+  Please include a list of explicit instructions for testing this PR.
+  If the instructions are 'run `make test`' say that,
+  If they are more complicated be thorough.
+-->
+
+1. Do X.
+2. Do Y.
+3. See Z.
+
+@osuosl/devs

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
 
 CLI for the TimeSync API
 
-This is not an official TimeSync client, and is not officially supported by the
-OSL. This CLI is used internally by the OSL for time-tracking purposes during
-development of other tools.
+Climesync is a CLI frontend to submit times to a TimeSync implementation.
 
 Install and Run
 ---------------


### PR DESCRIPTION
Climesync is now maintained by an OSL developer and will likely
be the primary tool for communicating with TimeSync for a while.
This should be reflected in the README.

Since this is becoming a useful too, we should us a Github PR
template to make testing easier. This is specifically important
for Climesync because it has one main developer. Reviewers will
not be familiar with the codebase and the clear outline the template
provides will be very helpful.

@aaroncohen73 @Kennric @ElijahCaine 