### PR TITLE
Detect empty lists returned from get_*

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -283,6 +283,8 @@ Examples:
     if not ts:
         return {"error": "Not connected to TimeSync server"}
 
+    interactive = False if post_data else True
+
     # Optional filtering parameters to send to the server
     if post_data is None:
         post_data = util.get_fields([("*!user", "Submitted by users"),
@@ -315,7 +317,7 @@ Examples:
     if times and 'error' not in times[0] and 'pymesync error' not in times[0]:
         for time in times:
             time["duration"] = util.to_readable_time(time["duration"])
-    elif not times:
+    elif interactive and not times:
         return {"note": "No times were returned"}
 
     # Attempt to query the server for times with filtering parameters
@@ -583,6 +585,8 @@ Examples:
     if not ts:
         return {"error": "Not connected to TimeSync server"}
 
+    interactive = False if post_data else True
+
     # Optional filtering parameters
     if post_data is None:
         post_data = util.get_fields([("*?include_revisions", "Allow revised?"),
@@ -592,7 +596,7 @@ Examples:
     # Attempt to query the server with filtering parameters
     projects = ts.get_projects(query_parameters=post_data)
 
-    if not projects:
+    if interactive and not projects:
         return {"note": "No projects were returned"}
 
     return projects
@@ -728,6 +732,8 @@ Examples:
     if not ts:
         return {"error": "Not connected to TimeSync server"}
 
+    interactive = False if post_data else True
+
     # Optional filtering parameters
     if post_data is None:
         post_data = util.get_fields([("*?include_revisions", "Allow revised?"),
@@ -737,7 +743,7 @@ Examples:
     # Attempt to query the server with filtering parameters
     activities = ts.get_activities(query_parameters=post_data)
 
-    if not activities:
+    if interactive and not activities:
         return {"note": "No activities were returned"}
 
     return activities
@@ -912,6 +918,8 @@ Examples:
     if not ts:
         return {"error": "Not connected to TimeSync server"}
 
+    interactive = False if post_data else True
+
     # Optional filtering parameters
     if post_data is None:
         post_data = util.get_fields([("*username", "Username")])
@@ -922,7 +930,7 @@ Examples:
     # Attempt to query the server with filtering parameters
     users = ts.get_users(username=username)
 
-    if not users:
+    if interactive and not users:
         return {"note": "No users were returned"}
 
     return users

--- a/commands.py
+++ b/commands.py
@@ -315,6 +315,8 @@ Examples:
     if times and 'error' not in times[0] and 'pymesync error' not in times[0]:
         for time in times:
             time["duration"] = util.to_readable_time(time["duration"])
+    elif not times:
+        return {"note": "No times were returned"}
 
     # Attempt to query the server for times with filtering parameters
     return times
@@ -588,7 +590,12 @@ Examples:
                                      ("*slug", "By project slug")])
 
     # Attempt to query the server with filtering parameters
-    return ts.get_projects(query_parameters=post_data)
+    projects = ts.get_projects(query_parameters=post_data)
+
+    if not projects:
+        return {"note": "No projects were returned"}
+
+    return projects
 
 
 @climesync_command(select_arg="slug")
@@ -728,7 +735,12 @@ Examples:
                                      ("*slug", "By activity slug")])
 
     # Attempt to query the server with filtering parameters
-    return ts.get_activities(query_parameters=post_data)
+    activities = ts.get_activities(query_parameters=post_data)
+
+    if not activities:
+        return {"note": "No activities were returned"}
+
+    return activities
 
 
 @climesync_command(select_arg="slug")
@@ -908,7 +920,12 @@ Examples:
     username = post_data.get("username")
 
     # Attempt to query the server with filtering parameters
-    return ts.get_users(username=username)
+    users = ts.get_users(username=username)
+
+    if not users:
+        return {"note": "No users were returned"}
+
+    return users
 
 
 @climesync_command(select_arg="username")

--- a/util.py
+++ b/util.py
@@ -75,20 +75,26 @@ def write_config(key, value, path="~/.climesyncrc"):
 def print_json(response):
     """Prints values returned by Pymesync nicely"""
 
-    print
+    if not response:
+        return
 
     if isinstance(response, list):  # List of dictionaries
+        print 
+
         for json_dict in response:
             for key, value in json_dict.iteritems():
                 print u"{}: {}".format(key, value)
 
             print
     elif isinstance(response, dict):  # Plain dictionary
+        print
+
         for key, value in response.iteritems():
             print u"{}: {}".format(key, value)
 
         print
     else:
+        print
         print "I don't know how to print that!"
         print response
         print

--- a/util.py
+++ b/util.py
@@ -75,22 +75,23 @@ def write_config(key, value, path="~/.climesyncrc"):
 def print_json(response):
     """Prints values returned by Pymesync nicely"""
 
-    print ""
+    print
 
     if isinstance(response, list):  # List of dictionaries
         for json_dict in response:
             for key, value in json_dict.iteritems():
                 print u"{}: {}".format(key, value)
 
-            print ""
+            print
     elif isinstance(response, dict):  # Plain dictionary
         for key, value in response.iteritems():
             print u"{}: {}".format(key, value)
 
-        print ""
+        print
     else:
         print "I don't know how to print that!"
         print response
+        print
 
 
 def is_time(time_str):

--- a/util.py
+++ b/util.py
@@ -79,7 +79,7 @@ def print_json(response):
         return
 
     if isinstance(response, list):  # List of dictionaries
-        print 
+        print
 
         for json_dict in response:
             for key, value in json_dict.iteritems():


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #55 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] When a `get_*` function returns an empty list, detect it and tell the user that no objects were returned

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Run `nosetests`
2. Run climesync and then run "gt" to get times
3. When prompted to filter the times by users, enter the user "notimesuser" and see that a note is printed to tell you that no times were returned.

@osuosl/devs

