### PR TITLE
Get users by project association and role

### DIFF
--- a/climesync/commands.py
+++ b/climesync/commands.py
@@ -1050,13 +1050,13 @@ Examples:
                 role = ""
 
         users = []
-        for username, roles in project_users.iteritems():
+        for user, roles in project_users.iteritems():
             if (role == "--members" and "member" not in roles) or \
                (role == "--managers" and "manager" not in roles) or \
                (role == "--spectators" and "spectator" not in roles):
                 continue
 
-            user_object = ts.get_users(username=username)[0]
+            user_object = ts.get_users(username=user)[0]
 
             if "error" in user_object or "pymesync error" in user_object:
                 return user_object

--- a/commands.py
+++ b/commands.py
@@ -919,7 +919,9 @@ Options:
 Examples:
     climesync.py get-users
 
-    climesync.py get-users userfour
+    climesync.py get-users --username=userfour
+
+    climesync.py get-users --project=p_foo --managers
     """
 
     global ts

--- a/commands.py
+++ b/commands.py
@@ -901,14 +901,16 @@ Examples:
                                      ("*?active", "Is the user active?")])
 
     # Attempt to update the user and return the response
-    return ts.update_user(user=post_data, username=old_username) 
+    return ts.update_user(user=post_data, username=old_username)
+
 
 @climesync_command(optional_args=True)
 def get_users(post_data=None, role=None):
     """get-users
 
 Usage: get-users [-h] [--username=<username>] |
-                     ([--project=<project> [--members|--managers|--spectators]])
+                     ([--project=<project>
+                      [--members|--managers|--spectators]])
 
 Options:
     -h --help              Show this help message and exit

--- a/util.py
+++ b/util.py
@@ -302,7 +302,8 @@ def fix_args(args, optional_args):
         elif arg.isupper():
             fixed_arg = arg.lower()
         # If it's a long option
-        elif arg[0:2] == '--' and arg != "--help":
+        elif arg[0:2] == '--' and arg not in ("--help", "--members",
+                                              "--managers", "--spectators"):
             fixed_arg = arg[2:].replace('-', '_')
         # If it's the help option or we don't know
         else:
@@ -316,6 +317,9 @@ def fix_args(args, optional_args):
                 fixed_value = int(value)
             else:
                 fixed_value = value
+        # If the value is a boolean (flag) value
+        elif isinstance(value, bool):
+            fixed_value = value
         # If the value is a space-delimited list
         elif value and value[0] == "[" and value[-1] == "]":
             fixed_value = value[1:-1].split()


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->

fixes issue #67 
## Changes in this PR.

<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->
- [X] `gu` now has an option to filter users by project association and then by project role
- [X] `get-users` now has the options `--project`, `--members`, `--spectators`, and `--managers` which can be used to filter users by project association
## Testing this PR.

<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->
1. Run `nosetests`
2. Run Climesync, connect to the staging server, and login as `admin`/`timesync-staging`
3. Run `gu` and enter the slug `ps` when asked for a project slug. Answer `N` when asked if you want to filter members/managers/spectators. See that two users are returned
4. Run `climesync/climesync.py get-users --project=ps` and see that two users are returned
5. Run `gu` and enter the slug `ps` again, but enter `Y` when asked to filter by project managers. See that only the `admin` user is returned
6. Run `climesync/climesync.py get-users --project=ps --managers` and see that only `admin` is returned

@osuosl/devs
