### PR TITLE
Tell user to sign in if they have not already

### DIFF
--- a/climesync/commands.py
+++ b/climesync/commands.py
@@ -44,8 +44,7 @@ class climesync_command():
                 return command(**command_kwargs)
             else:
                 if util.check_token_expiration(ts):
-                    return {"error": "Your token has expired. Please sign in "
-                                     "again"}
+                    return {"error": "You need to sign in."}
 
                 return command()
 

--- a/climesync/util.py
+++ b/climesync/util.py
@@ -79,6 +79,10 @@ def check_token_expiration(ts):
     """Checks to see if the auth token has expired. If it has, try to log the
     user back in using the username and password in their config file"""
 
+    # If ts_token_expiration_time() returns a dict, there must be an error
+    if type(ts.token_expiration_time()) is dict:
+        return True
+
     # If the token is expired, try to log the user back in
     if ts and not ts.test and ts.token_expiration_time() <= datetime.now():
         config = read_config()


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
Fixes #98 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Change "token expired" error to more general "need to sign in" 
- [X] Check if `token_expiration_time()` returns a dict

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Run climesync
2. Enter `so` to sign out
3. Try any command that requires authentication, such as `gt`
4. See as it tells you to sign in

@osuosl/devs

