### PR TITLE
Fix optional args not being optional

### DIFF
--- a/climesync/commands.py
+++ b/climesync/commands.py
@@ -168,7 +168,7 @@ def update_settings():
     return ts.update_user(user=post_data, username=username)
 
 
-@climesync_command()
+@climesync_command(optional_args=True)
 def create_time(post_data=None):
     """create-time
 


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
Fixes #103 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Add `optional_args = True` for `create_time`

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Create a time from the command line: `climesync.py create-time 0h5m climesync testing`
2. See response:

```
activities: testing
date_worked: 2016-08-05
uuid: 80cbbdaa-1d5e-4370-b10f-14bce69279f4
project: climesync
user: <your_username>
duration: 0h5m
revision: 1
```

@osuosl/devs

