### PR TITLE
Ask users if they want to use LDAP on sign-in

### DIFF
--- a/climesync/climesync.py
+++ b/climesync/climesync.py
@@ -181,14 +181,12 @@ def main(argv=None, test=False):
                 config_obj.getboolean("climesync", "autoupdate_config")
 
         config_dict = dict(config_obj.items("climesync"))
+
+        # Turn "ldap" into a bool instead of a string
+        if config_obj.has_option("climesync", "ldap"):
+            config_dict["ldap"] = config_obj.getboolean("climesync", "ldap")
     except:
         config_dict = {}
-
-    if ldap or \
-       ("ldap" in config_dict and config_dict["ldap"].lower() == "true"):
-        commands.ldap = True
-    else:
-        commands.ldap = False
 
     # Attempt to connect with arguments and/or config
     response = commands.connect(arg_url=url, config_dict=config_dict,
@@ -198,7 +196,7 @@ def main(argv=None, test=False):
         util.print_json(response)
 
     response = commands.sign_in(arg_user=user, arg_pass=password,
-                                config_dict=config_dict,
+                                arg_ldap=ldap, config_dict=config_dict,
                                 interactive=interactive)
 
     if "error" in response or "pymesync error" in response or \

--- a/climesync/commands.py
+++ b/climesync/commands.py
@@ -13,7 +13,6 @@ projects = None
 activities = None
 
 autoupdate_config = True
-ldap = False  # Use LDAP?
 
 
 # climesync_command decorator
@@ -107,7 +106,8 @@ def disconnect():
     return list()
 
 
-def sign_in(arg_user="", arg_pass="", config_dict=dict(), interactive=True):
+def sign_in(arg_user="", arg_pass="", arg_ldap=None, config_dict=dict(),
+            interactive=True):
     """Attempts to sign in with user-supplied or command line credentials"""
 
     global ts, user, users, projects, activities, autoupdate_config, ldap
@@ -117,7 +117,7 @@ def sign_in(arg_user="", arg_pass="", config_dict=dict(), interactive=True):
 
     username = ""
     password = ""
-    auth_type = "ldap" if ldap else "password"
+    ldap = None
 
     # If username or password in config, use them at program startup.
     if arg_user:
@@ -134,14 +134,24 @@ def sign_in(arg_user="", arg_pass="", config_dict=dict(), interactive=True):
     elif interactive:
         password = util.get_field("Password", field_type="$")
 
-    if not username or not password:
+    if arg_ldap:
+        ldap = arg_ldap
+    elif "ldap" in config_dict:
+        ldap = config_dict["ldap"]
+    elif interactive:
+        ldap = util.get_field("Authenticate using LDAP", field_type="?")
+
+    if not username or not password or ldap is None:
         return {"climesync error": "Couldn't authenticate with TimeSync. Are "
-                                   "username and password set in "
+                                   "username, password, and ldap set in "
                                    "~/.climesyncrc?"}
 
     if interactive and not ts.test and autoupdate_config:
         util.add_kv_pair("username", username)
         util.add_kv_pair("password", password)
+        util.add_kv_pair("ldap", ldap)
+
+    auth_type = "ldap" if ldap else "password"
 
     # Attempt to authenticate and return the server's response
     res = ts.authenticate(username, password, auth_type)

--- a/climesync/util.py
+++ b/climesync/util.py
@@ -72,6 +72,9 @@ def write_config(key, value, path="~/.climesyncrc"):
     if "climesync" not in config.sections():
         create_config(path)
 
+    # Make sure the value is a string so it can be encoded
+    value = u"{}".format(value)
+
     # Attempt to set the option value in the config
     # If the "climesync" section doesn't exist (NoSectionError), create it
     try:
@@ -667,9 +670,17 @@ def add_kv_pair(key, value, path="~/.climesyncrc"):
 
     config = read_config(path)
 
+    # Get the current value in the config if there is one
+    if config.has_option("climesync", key):
+        if isinstance(value, bool):
+            current_value = config.getboolean("climesync", key)
+        else:
+            current_value = config.get("climesync", key)
+    else:
+        current_value = None
+
     # If that key/value pair is already in the config, skip asking
-    if config.has_option("climesync", key) \
-       and config.get("climesync", key) == value:
+    if current_value is not None and value == current_value:
         return
 
     if key == "password":

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -19,9 +19,11 @@ Climesync currently supports the following versions of the TimeSync API:
 Install Climesync
 -----------------
 
-To install Climesync from git, run the following commands:
+To install Climesync from PyPI (Recommended), run the following command::
 
-.. code-block:: none
+    $ pip install climesync
+
+To install Climesync from git, run the following commands::
 
     $ git clone https://github.com/osuosl/climesync && cd climesync
     $ python setup.py install
@@ -41,6 +43,7 @@ Climesync also accepts several optional command line arguments
 -c <URL>, --connect <URL>             Connect to a TimeSync server on startup
 -u <username>, --user <username>      Attempt to authenticate on startup with the given username
 -p <password>, --password <password>  Attempt to authenticate on startup with the given password
+-l, --ldap                            Attempt to authenticate using LDAP
 
 Since server information and user credentials can be specified in multiple
 places (See `Climesync Configuration`_ below), these values are prioritized
@@ -133,7 +136,7 @@ as a space-separated list enclosed within square brackets. For example:
 
 .. code-block:: none
 
-    (venv) $ ./climesync.py get-times --user="[user1 user2 user3]"
+    $ climesync get-times --user="[user1 user2 user3]"
 
 This example gets all the time entries submitted either by user1, user2, or user3.
 
@@ -145,19 +148,19 @@ To get a list of scripting mode commands, run
 
 .. code-block:: none
 
-    (venv) $ ./climesync.py --help
+    $ climesync --help
 
 To get help for a specific scripting mode command, run
 
 .. code-block:: none
 
-    (venv) $ ./climesync.py <command_name> --help
+    $ climesync <command_name> --help
 
 Climesync Configuration
 -----------------------
 
 On the first run of the program in interactive mode, the configuration file
-`.climesyncrc` is created in the user's home directory. This configuration
+``.climesyncrc`` is created in the user's home directory. This configuration
 file stores server information and user credentials. If Climesync is going to
 only be run in interactive mode then manually editing this file manually won't
 be necessary because Climesync will handle updating these values while it's
@@ -174,6 +177,7 @@ in .climesyncrc:
 timesync_url      The URL of the TimeSync server to connect to on startup
 username          The username of the user to authenticate as on startup
 password          The password of the user to authenticate as on startup
+ldap              Use LDAP to authenticate
 autoupdate_config Turn off prompts to automatically update your config
                   when connecting to a new server or signing in as a new
                   user

--- a/testing/test_climesync.py
+++ b/testing/test_climesync.py
@@ -104,10 +104,13 @@ class ClimesyncTest(unittest.TestCase):
     def test_sign_in_args(self, mock_ts):
         username = "test"
         password = "password"
+        ldap = True
 
-        commands.sign_in(arg_user=username, arg_pass=password)
+        mock_ts.test = True
 
-        mock_ts.authenticate.assert_called_with(username, password, "password")
+        commands.sign_in(arg_user=username, arg_pass=password, arg_ldap=ldap)
+
+        mock_ts.authenticate.assert_called_with(username, password, "ldap")
 
         assert not util.ts_error(commands.user, commands.users,
                                  commands.projects, commands.activities)
@@ -116,11 +119,13 @@ class ClimesyncTest(unittest.TestCase):
     def test_sign_in_config_dict(self, mock_ts):
         username = "test"
         password = "password"
-        config_dict = {"username": username, "password": password}
+        ldap = True
+        config_dict = {"username": username, "password": password,
+                       "ldap": ldap}
 
         commands.sign_in(config_dict=config_dict)
 
-        mock_ts.authenticate.assert_called_with(username, password, "password")
+        mock_ts.authenticate.assert_called_with(username, password, "ldap")
 
         assert not util.ts_error(commands.user, commands.users,
                                  commands.projects, commands.activities)
@@ -130,14 +135,15 @@ class ClimesyncTest(unittest.TestCase):
     def test_sign_in_interactive(self, mock_ts, mock_util):
         username = "test"
         password = "test"
-        mocked_input = [username, password]
+        ldap = True
+        mocked_input = [username, password, ldap]
 
         mock_util.ts_error = util.ts_error
         mock_util.get_field.side_effect = mocked_input
 
         commands.sign_in()
 
-        mock_ts.authenticate.assert_called_with(username, password, "password")
+        mock_ts.authenticate.assert_called_with(username, password, "ldap")
 
         assert not util.ts_error(commands.user, commands.users,
                                  commands.projects, commands.activities)
@@ -146,11 +152,14 @@ class ClimesyncTest(unittest.TestCase):
     def test_sign_in_noninteractive(self, mock_ts):
         username = "test"
         password = "test"
+        ldap = True
 
-        commands.sign_in(arg_user=username, arg_pass=password,
+        mock_ts.test = True
+
+        commands.sign_in(arg_user=username, arg_pass=password, arg_ldap=ldap,
                          interactive=False)
 
-        mock_ts.authenticate.assert_called_with(username, password, "password")
+        mock_ts.authenticate.assert_called_with(username, password, "ldap")
 
         assert not util.ts_error(commands.user, commands.users,
                                  commands.projects, commands.activities)
@@ -231,11 +240,13 @@ class ClimesyncTest(unittest.TestCase):
         baseurl = "ts_url"
         username = "test"
         password = "password"
+        ldap = False
         argv = ["-c", baseurl, "-u", username, "-p", password]
 
         config_dict = {}
 
         mock_config = MagicMock()
+        mock_config.has_option.return_value = False
         mock_config.items.return_value = config_dict
 
         mock_util.read_config.return_value = mock_config
@@ -248,6 +259,7 @@ class ClimesyncTest(unittest.TestCase):
                                                  test=True)
         mock_commands.sign_in.assert_called_with(arg_user=username,
                                                  arg_pass=password,
+                                                 arg_ldap=ldap,
                                                  config_dict=config_dict,
                                                  interactive=True)
         mock_interactive_mode.assert_called_with()

--- a/testing/test_commands.py
+++ b/testing/test_commands.py
@@ -18,7 +18,8 @@ class test_command():
         self.config = {
             "timesync_url": "test",
             "username": "test",
-            "password": "test"
+            "password": "test",
+            "ldap": False
         }
 
     def authenticate_nonadmin(self):

--- a/testing/test_scripting.py
+++ b/testing/test_scripting.py
@@ -17,7 +17,8 @@ class test_script():
         self.config = {
             "timesync_url": "test",
             "username": "test",
-            "password": "test"
+            "password": "test",
+            "ldap": False
         }
 
     def authenticate_nonadmin(self):


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->

fixes issue #101 
## Changes in this PR.

<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->
- [X] Ask user if they want to use LDAP when they sign in either on first run or with `s`
- [X] `sign_in` now automatically manages the `ldap` option in ~/.climesyncrc
## Testing this PR.

<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->
1. Run `nosetests`
2. Run Climesync with `climesync/climesync.py` and connect to `https://timesync.osuosl.org/v0`
3. Sign in with your LDAP credentials and answer `y` when asked if you want to use LDAP
4. See that you are successfully signed in

@osuosl/devs
