### PR TITLE
Cohenaa/validate inputs

### DIFF
--- a/climesync/commands.py
+++ b/climesync/commands.py
@@ -151,8 +151,11 @@ def sign_in(arg_user="", arg_pass="", config_dict=dict(), interactive=True):
         if not util.ts_error(users, projects, activities):
             if ts.test:
                 user = users[0]
+                user["projects"] = []
             else:
                 user = {u["username"]: u for u in users}[username]
+                user["projects"] = [p for p in projects
+                                    if user["username"] in projects["users"]]
 
             users = [u["username"] for u in users]
             projects = [p["slugs"][0] for p in projects]
@@ -237,7 +240,7 @@ Examples:
     climesync.py create-time 0h45m projecty design --notes="Designing the API"
     """
 
-    global ts, projects, activities
+    global ts, user, activities
 
     if not ts:
         return {"error": "Not connected to TimeSync server"}
@@ -247,7 +250,7 @@ Examples:
         post_data = util.get_fields([(":duration",   "Duration"),
                                      ("date_worked", "Date (yyyy-mm-dd)"),
                                      ("project",     "Project slug",
-                                      projects)])
+                                      user["projects"])])
 
         project_slug = post_data["project"]
 
@@ -315,7 +318,7 @@ Examples:
 `       --project=projecty --notes="Notes notes notes"
     """
 
-    global ts, projects, activities
+    global ts, user, activities
 
     if not ts:
         return {"error": "Not connected to TimeSync server"}
@@ -332,7 +335,7 @@ Examples:
 
         post_data = util.get_fields([("*:duration",   "Duration"),
                                      ("*project",     "Project slug",
-                                      projects),
+                                      user["projects"]),
                                      ("*!activities", "Activity slugs",
                                       activities),
                                      ("*date_worked", "Date (yyyy-mm-dd)"),

--- a/climesync/commands.py
+++ b/climesync/commands.py
@@ -59,7 +59,7 @@ class climesync_command():
 def connect(arg_url="", config_dict=dict(), test=False, interactive=True):
     """Creates a new pymesync.TimeSync instance with a new URL"""
 
-    global ts, autoupdate_config
+    global ts, user, users, projects, activities, autoupdate_config
 
     url = ""
 
@@ -160,7 +160,7 @@ def sign_in(arg_user="", arg_pass="", config_dict=dict(), interactive=True):
         else:
             for o in (users, projects, activities):
                 util.ts_error(o)
-            
+
             users = None
             projects = None
             activities = None
@@ -246,7 +246,8 @@ Examples:
     if post_data is None:
         post_data = util.get_fields([(":duration",   "Duration"),
                                      ("date_worked", "Date (yyyy-mm-dd)"),
-                                     ("project",     "Project slug", projects)])
+                                     ("project",     "Project slug",
+                                      projects)])
 
         project_slug = post_data["project"]
 
@@ -260,7 +261,8 @@ Examples:
         else:
             activity_query = "!activities"
 
-        post_data_cont = util.get_fields([(activity_query, "Activity slugs", activities),
+        post_data_cont = util.get_fields([(activity_query, "Activity slugs",
+                                           activities),
                                           ("*issue_uri",  "Issue URI"),
                                           ("*notes",      "Notes")])
 
@@ -287,7 +289,6 @@ def update_time(post_data=None, uuid=None):
 
 Usage: update-time [-h] <uuid> [--duration=<duration>]
                         [--project=<project>]
-                        [--user=<user>]
                         [--activities=<activities>]
                         [--date-worked=<date worked>]
                         [--issue-uri=<issue uri>]
@@ -330,8 +331,10 @@ Examples:
             return current_time
 
         post_data = util.get_fields([("*:duration",   "Duration"),
-                                     ("*project",     "Project slug", projects),
-                                     ("*!activities", "Activity slugs", activities),
+                                     ("*project",     "Project slug",
+                                      projects),
+                                     ("*!activities", "Activity slugs",
+                                      activities),
                                      ("*date_worked", "Date (yyyy-mm-dd)"),
                                      ("*issue_uri",   "Issue URI"),
                                      ("*notes",       "Notes")],
@@ -387,8 +390,10 @@ Examples:
     # Optional filtering parameters to send to the server
     if post_data is None:
         post_data = util.get_fields([("*!user", "Submitted by users", users),
-                                     ("*!project", "Belonging to projects", projects),
-                                     ("*!activity", "Belonging to activities", activities),
+                                     ("*!project", "Belonging to projects",
+                                      projects),
+                                     ("*!activity", "Belonging to activities",
+                                      activities),
                                      ("*start", "Beginning on date"),
                                      ("*end", "Ending on date"),
                                      ("*?include_revisions", "Allow revised?"),
@@ -682,7 +687,8 @@ Examples:
         if "error" in current_project or "pymesync error" in current_project:
             return current_project
 
-        post_data = util.get_fields([("*!users", "Users to add/update", users)],
+        post_data = util.get_fields([("*!users", "Users to add/update",
+                                      users)],
                                     current_object=current_project)
     else:
         permissions_dict = dict(zip(post_data.pop("username"),
@@ -914,7 +920,8 @@ Examples:
         return {"error": "Not connected to TimeSync server"}
 
     if old_slug is None:
-        old_slug = util.get_field("Slug of activity to update", validator=activities)
+        old_slug = util.get_field("Slug of activity to update",
+                                  validator=activities)
 
     # The data to send to the server containing revised activity information
     if post_data is None:
@@ -964,7 +971,8 @@ Examples:
     if post_data is None:
         post_data = util.get_fields([("*?include_revisions", "Allow revised?"),
                                      ("*?include_deleted", "Allow deleted?"),
-                                     ("*slug", "By activity slug", activities)])
+                                     ("*slug", "By activity slug",
+                                      activities)])
 
     # Attempt to query the server with filtering parameters
     activities_res = ts.get_activities(query_parameters=post_data)
@@ -1105,7 +1113,8 @@ Examples:
         return {"error": "Not connected to TimeSync server"}
 
     if old_username is None:
-        old_username = util.get_field("Username of user to update", validator=users)
+        old_username = util.get_field("Username of user to update",
+                                      validator=users)
 
     # The data to send to the server containing revised user information
     if post_data is None:
@@ -1174,7 +1183,8 @@ Examples:
         meta = None
 
     if interactive and not username:
-        post_data.update(util.get_fields([("*project", "By project slug", projects)]))
+        post_data.update(util.get_fields([("*project", "By project slug",
+                                           projects)]))
 
     project = post_data.get("project")
 

--- a/climesync/commands.py
+++ b/climesync/commands.py
@@ -160,7 +160,8 @@ def sign_in(arg_user="", arg_pass="", config_dict=dict(), interactive=True):
             else:
                 user = {u["username"]: u for u in users}[username]
                 user["projects"] = [p for p in projects
-                                    if user["username"] in p["users"]]
+                                    if "users" in p
+                                    and user["username"] in p["users"]]
                 user["project_slugs"] = [p["slugs"][0]
                                          for p in user["projects"]]
 

--- a/climesync/commands.py
+++ b/climesync/commands.py
@@ -51,7 +51,11 @@ class climesync_command():
                 if util.check_token_expiration(ts):
                     return {"error": "You need to sign in."}
 
-                return command()
+                try:
+                    return command()
+                except IndexError as e:
+                    print e
+                    return []
 
         return wrapped_command
 
@@ -152,10 +156,13 @@ def sign_in(arg_user="", arg_pass="", config_dict=dict(), interactive=True):
             if ts.test:
                 user = users[0]
                 user["projects"] = []
+                user["project_slugs"] = ["test"]
             else:
                 user = {u["username"]: u for u in users}[username]
                 user["projects"] = [p for p in projects
-                                    if user["username"] in projects["users"]]
+                                    if user["username"] in p["users"]]
+                user["project_slugs"] = [p["slugs"][0]
+                                         for p in user["projects"]]
 
             users = [u["username"] for u in users]
             projects = [p["slugs"][0] for p in projects]
@@ -250,7 +257,7 @@ Examples:
         post_data = util.get_fields([(":duration",   "Duration"),
                                      ("date_worked", "Date (yyyy-mm-dd)"),
                                      ("project",     "Project slug",
-                                      user["projects"])])
+                                      user["project_slugs"])])
 
         project_slug = post_data["project"]
 
@@ -335,7 +342,7 @@ Examples:
 
         post_data = util.get_fields([("*:duration",   "Duration"),
                                      ("*project",     "Project slug",
-                                      user["projects"]),
+                                      user["project_slugs"]),
                                      ("*!activities", "Activity slugs",
                                       activities),
                                      ("*date_worked", "Date (yyyy-mm-dd)"),

--- a/climesync/commands.py
+++ b/climesync/commands.py
@@ -256,7 +256,7 @@ Examples:
     # The data to send to the server containing the new time information
     if post_data is None:
         post_data = util.get_fields([(":duration",   "Duration"),
-                                     ("date_worked", "Date (yyyy-mm-dd)"),
+                                     ("~date_worked", "Date worked"),
                                      ("project",     "Project slug",
                                       user["project_slugs"])])
 
@@ -346,7 +346,7 @@ Examples:
                                       user["project_slugs"]),
                                      ("*!activities", "Activity slugs",
                                       activities),
-                                     ("*date_worked", "Date (yyyy-mm-dd)"),
+                                     ("*~date_worked", "Date worked"),
                                      ("*issue_uri",   "Issue URI"),
                                      ("*notes",       "Notes")],
                                     current_object=current_time)
@@ -405,8 +405,8 @@ Examples:
                                       projects),
                                      ("*!activity", "Belonging to activities",
                                       activities),
-                                     ("*start", "Beginning on date"),
-                                     ("*end", "Ending on date"),
+                                     ("*~start", "Beginning on date"),
+                                     ("*~end", "Ending on date"),
                                      ("*?include_revisions", "Allow revised?"),
                                      ("*?include_deleted", "Allow deleted?"),
                                      ("*uuid", "By UUID")])
@@ -459,8 +459,8 @@ Examples:
 
     if post_data is None:
         post_data = util.get_fields([("!project", "Project slugs", projects),
-                                     ("*start", "Start date (yyyy-mm-dd)"),
-                                     ("*end", "End date (yyyy-mm-dd)")])
+                                     ("*~start", "Start date"),
+                                     ("*~end", "End date")])
 
     if isinstance(post_data["project"], str):
         post_data["project"] = [post_data["project"]]

--- a/climesync/util.py
+++ b/climesync/util.py
@@ -9,6 +9,16 @@ from datetime import datetime
 from getpass import getpass
 
 
+def ts_error(*ts_objects):
+    for ts_object in ts_objects:
+        if isinstance(ts_object, list):
+            ts_object = ts_object[0]
+
+        if "error" in ts_object or "pymesync error" in ts_object:
+            print_json(ts_object)
+            return True
+
+
 def create_config(path="~/.climesyncrc"):
     """Create the configuration file if it doesn't exist"""
 

--- a/climesync/util.py
+++ b/climesync/util.py
@@ -7,7 +7,6 @@ import sys  # NOQA flake8 ignore
 from collections import OrderedDict
 from datetime import datetime
 from getpass import getpass
-from itertools import chain, islice, repeat
 
 
 def ts_error(*ts_objects):
@@ -550,7 +549,7 @@ def get_fields(fields, current_object=None):
     In addition to those, field_name can contain a * for an optional field
     """
     responses = dict()
-    
+
     for field, prompt, validator in [(f + (None,))[:3] for f in fields]:
         optional = False
         field_type = ""

--- a/climesync/util.py
+++ b/climesync/util.py
@@ -536,6 +536,8 @@ def get_field(prompt, optional=False, field_type="", validator=None,
                     return response
 
         print "Please submit a valid input"
+        if validator:
+            print "Valid choices: [{}]".format(", ".join(validator))
 
 
 def get_fields(fields, current_object=None):

--- a/climesync/util.py
+++ b/climesync/util.py
@@ -130,6 +130,20 @@ def is_time(time_str):
     return True if re.match(r"\A[\d]+h[\d]+m\Z", time_str) else False
 
 
+def is_date(date_str):
+    """Checks if the supplied string is formatted as an ISO 8601 datestring
+
+    i.e. 2016-04-01, 2015-03-14, etc.
+    """
+
+    try:
+        datetime.strptime(date_str, "%Y-%m-%d")
+    except ValueError:  # If strptime fails, a ValueError is raised
+        return False
+
+    return True
+
+
 def to_readable_time(seconds):
     """Converts a time in seconds to a human-readable format"""
 
@@ -461,6 +475,7 @@ def get_field(prompt, optional=False, field_type="", validator=None,
     Valid field_types:
     ? - Yes/No input
     : - Time input
+    ~ - Date input
     ! - Multiple inputs delimited by commas returned as a list
     $ - Password input
     """
@@ -484,6 +499,8 @@ def get_field(prompt, optional=False, field_type="", validator=None,
             type_prompt = "(y/n) "
     elif field_type == ":":
         type_prompt = "(Time input - <value>h<value>m) "
+    elif field_type == '~':
+        type_prompt = "(Date input - YYYY-MM-DD) "
     elif field_type == "!":
         type_prompt = "(Comma delimited) "
     elif field_type == "$":
@@ -519,6 +536,9 @@ def get_field(prompt, optional=False, field_type="", validator=None,
             elif field_type == ":":
                 if is_time(response):
                     return response
+            elif field_type == "~":
+                if is_date(response):
+                    return response
             elif field_type == "!":
                 response = [r.strip() for r in response.split(",")]
                 for r in response:
@@ -549,6 +569,7 @@ def get_fields(fields, current_object=None):
     field_name can contain special characters that signify input type
     ? - Yes/No field
     : - Time field
+    ~ - Date field
     ! - List field
     $ - Password field
 
@@ -575,6 +596,9 @@ def get_fields(fields, current_object=None):
         elif ":" in field:
             field_type = ":"  # Time
             field = field.replace(":", "")
+        elif "~" in field:
+            field_type = "~"  # Date
+            field = field.replace("~", "")
         elif "!" in field:
             field_type = "!"  # Comma-delimited list
             field = field.replace("!", "")

--- a/climesync/util.py
+++ b/climesync/util.py
@@ -465,6 +465,10 @@ def get_field(prompt, optional=False, field_type="", validator=None,
     $ - Password input
     """
 
+    # Check for an empty validator and raise an error
+    if validator == []:
+        raise IndexError("No valid choices for field '{}'".format(prompt))
+
     # If necessary, add extra prompts that inform the user
     optional_prompt = ""
     type_prompt = ""
@@ -550,7 +554,14 @@ def get_fields(fields, current_object=None):
     """
     responses = dict()
 
-    for field, prompt, validator in [(f + (None,))[:3] for f in fields]:
+    padded_fields = [(f + (None,))[:3] for f in fields]
+
+    # Check to see if any of the validators are empty lists
+    for _, prompt, validator in padded_fields:
+        if validator == []:
+            raise IndexError("No valid choices for field '{}'".format(prompt))
+
+    for field, prompt, validator in padded_fields:
         optional = False
         field_type = ""
         current = None

--- a/testing/test_climesync.py
+++ b/testing/test_climesync.py
@@ -1,6 +1,6 @@
 from StringIO import StringIO
 import unittest
-from mock import call, patch, MagicMock
+from mock import patch, MagicMock
 
 from climesync import climesync
 from climesync.climesync import command_lookup
@@ -14,7 +14,7 @@ class ClimesyncTest(unittest.TestCase):
         # Reset cached TS data between tests
         commands.user = None
         commands.users = None
-        commands.projects= None
+        commands.projects = None
         commands.activities = None
 
     def test_lookup_command_interactive(self):

--- a/testing/test_climesync.py
+++ b/testing/test_climesync.py
@@ -5,9 +5,17 @@ from mock import call, patch, MagicMock
 from climesync import climesync
 from climesync.climesync import command_lookup
 from climesync import commands
+from climesync import util
 
 
 class ClimesyncTest(unittest.TestCase):
+
+    def setUp(self):
+        # Reset cached TS data between tests
+        commands.user = None
+        commands.users = None
+        commands.projects= None
+        commands.activities = None
 
     def test_lookup_command_interactive(self):
         test_queries = [
@@ -92,34 +100,30 @@ class ClimesyncTest(unittest.TestCase):
 
         assert not commands.ts
 
-    @patch("climesync.commands.util")
     @patch("climesync.commands.ts")
-    def test_sign_in_args(self, mock_ts, mock_util):
+    def test_sign_in_args(self, mock_ts):
         username = "test"
         password = "password"
 
-        mock_ts.test = False
-
         commands.sign_in(arg_user=username, arg_pass=password)
 
-        mock_util.add_kv_pair.assert_has_calls([call("username", username),
-                                                call("password", password)])
         mock_ts.authenticate.assert_called_with(username, password, "password")
 
-    @patch("climesync.commands.util")
+        assert not util.ts_error(commands.user, commands.users,
+                                 commands.projects, commands.activities)
+
     @patch("climesync.commands.ts")
-    def test_sign_in_config_dict(self, mock_ts, mock_util):
+    def test_sign_in_config_dict(self, mock_ts):
         username = "test"
         password = "password"
         config_dict = {"username": username, "password": password}
 
-        mock_ts.test = False
-
         commands.sign_in(config_dict=config_dict)
 
-        mock_util.add_kv_pair.assert_has_calls([call("username", username),
-                                                call("password", password)])
         mock_ts.authenticate.assert_called_with(username, password, "password")
+
+        assert not util.ts_error(commands.user, commands.users,
+                                 commands.projects, commands.activities)
 
     @patch("climesync.commands.util")
     @patch("climesync.commands.ts")
@@ -128,28 +132,28 @@ class ClimesyncTest(unittest.TestCase):
         password = "test"
         mocked_input = [username, password]
 
+        mock_util.ts_error = util.ts_error
         mock_util.get_field.side_effect = mocked_input
-        mock_ts.test = False
 
         commands.sign_in()
 
-        mock_util.add_kv_pair.assert_has_calls([call("username", username),
-                                                call("password", password)])
         mock_ts.authenticate.assert_called_with(username, password, "password")
 
-    @patch("climesync.commands.util")
+        assert not util.ts_error(commands.user, commands.users,
+                                 commands.projects, commands.activities)
+
     @patch("climesync.commands.ts")
-    def test_sign_in_noninteractive(self, mock_ts, mock_util):
+    def test_sign_in_noninteractive(self, mock_ts):
         username = "test"
         password = "test"
-
-        mock_ts.test = False
 
         commands.sign_in(arg_user=username, arg_pass=password,
                          interactive=False)
 
-        mock_util.add_kv_pair.assert_not_called()
         mock_ts.authenticate.assert_called_with(username, password, "password")
+
+        assert not util.ts_error(commands.user, commands.users,
+                                 commands.projects, commands.activities)
 
     def test_sign_in_not_connected(self):
         commands.ts = None
@@ -158,11 +162,19 @@ class ClimesyncTest(unittest.TestCase):
 
         assert "error" in response
 
+        for o in (commands.user, commands.users, commands.projects,
+                  commands.activities):
+            assert not o
+
     @patch("climesync.commands.ts")
     def test_sign_in_error(self, mock_ts):
         response = commands.sign_in(interactive=False)
 
         assert "climesync error" in response
+
+        for o in (commands.user, commands.users, commands.projects,
+                  commands.activities):
+            assert not o
 
     @patch("climesync.commands.ts")
     @patch("climesync.commands.pymesync.TimeSync")
@@ -177,12 +189,20 @@ class ClimesyncTest(unittest.TestCase):
 
         mock_timesync.assert_called_with(baseurl=url, test=test)
 
+        for o in (commands.user, commands.users, commands.projects,
+                  commands.activities):
+            assert not o
+
     def test_sign_out_not_connected(self):
         commands.ts = None
 
         response = commands.sign_out()
 
         assert "error" in response
+
+        for o in (commands.user, commands.users, commands.projects,
+                  commands.activities):
+            assert not o
 
     @patch("climesync.climesync.commands")
     @patch("climesync.climesync.interactive_mode")

--- a/testing/test_commands.py
+++ b/testing/test_commands.py
@@ -69,6 +69,8 @@ class CommandsTest(unittest.TestCase):
 
     @test_command(data=test_data.update_time_data)
     def test_update_time(self, expected, result):
+        print result
+        print expected
         assert result == expected
 
     @test_command(data=test_data.get_times_no_uuid_data)

--- a/testing/test_data.py
+++ b/testing/test_data.py
@@ -47,14 +47,13 @@ update_time_data = TestData(
             "838853e3-3635-4076-a26f-7efr4e60981f",  # UUID of time to update
             "2h0m",  # Updated duration
             "p_bar",  # Updated project slug
-            "usertwo",  # Updated user
             ["docs"],  # Updated activity slugs
             "2016-06-20",  # Updated date worked
             "https://www.github.com/osuosl/projectbar/issues/5",  # Updated URI
             "Worked on documentation"  # Updated notes
         ],
         cli_args="838853e3-3635-4076-a26f-7efr4e60981f --duration=2h0m \
-             --project=p_bar --user=usertwo --activities=docs \
+             --project=p_bar --activities=docs \
              --date-worked=2016-06-20 \
              --issue-uri=https://www.github.com/osuosl/projectbar/issues/5 \
              --notes=\"Worked on documentation\"",
@@ -68,7 +67,7 @@ update_time_data = TestData(
             "project": "p_bar",
             "activities": ["docs"],
             "date_worked": "2016-06-20",
-            "user": "usertwo",
+            "user": "example-user",
             "notes": "Worked on documentation",
             "issue_uri": "https://www.github.com/osuosl/projectbar/issues/5"
         },

--- a/testing/test_util.py
+++ b/testing/test_util.py
@@ -11,6 +11,16 @@ from mock import patch, MagicMock
 
 class UtilTest(unittest.TestCase):
 
+    def test_ts_error_no_error(self):
+        ts_objects = [{"example": "object"}]
+
+        assert not util.ts_error(*ts_objects)
+
+    def test_ts_error_error(self):
+        ts_objects = [{"example": "object"}, {"error": 404}]
+
+        assert util.ts_error(*ts_objects)
+
     @patch("climesync.util.codecs.open")
     @patch("climesync.util.os.chmod")
     @patch("climesync.util.os.path")
@@ -246,6 +256,32 @@ class UtilTest(unittest.TestCase):
         mock_raw_input.assert_called_with(expected_formatted_prompt)
 
     @patch("climesync.util.raw_input")
+    def test_get_field_string_validated(self, mock_raw_input):
+        prompt = "Prompt"
+        validator = ["v1", "v2"]
+
+        mocked_input = "v1"
+
+        mock_raw_input.return_value = mocked_input
+
+        value = util.get_field(prompt, validator=validator)
+
+        assert value == "v1"
+
+    @patch("climesync.util.raw_input")
+    def test_get_field_string_invalid(self, mock_raw_input):
+        prompt = "Prompt"
+        validator = ["v1", "v2"]
+
+        mocked_input = ["v3", "v2"]
+
+        mock_raw_input.side_effect = mocked_input
+
+        value = util.get_field(prompt, validator=validator)
+
+        assert value == "v2"
+
+    @patch("climesync.util.raw_input")
     def test_get_field_bool_yes(self, mock_raw_input):
         prompt = "Prompt"
         expected_formatted_prompt = "(y/n) Prompt: "
@@ -405,6 +441,32 @@ class UtilTest(unittest.TestCase):
         mock_raw_input.assert_called_with(expected_formatted_prompt)
 
     @patch("climesync.util.raw_input")
+    def test_get_field_list_validated(self, mock_raw_input):
+        prompt = "Prompt"
+        validator = ["v1", "v2", "v3"]
+
+        mocked_input = "v1, v3"
+
+        mock_raw_input.return_value = mocked_input
+
+        value = util.get_field(prompt, field_type="!", validator=validator)
+
+        assert value == ["v1", "v3"]
+
+    @patch("climesync.util.raw_input")
+    def test_get_field_list_invalid(self, mock_raw_input):
+        prompt = "Prompt"
+        validator = ["v1", "v2", "v3"]
+
+        mocked_input = ["v1, v4, v2", "v1, v2"]
+
+        mock_raw_input.side_effect = mocked_input
+
+        value = util.get_field(prompt, field_type="!", validator=validator)
+
+        assert value == ["v1", "v2"]
+
+    @patch("climesync.util.raw_input")
     def test_get_field_type_invalid(self, mock_raw_input):
         prompt = "Prompt"
 
@@ -415,13 +477,13 @@ class UtilTest(unittest.TestCase):
     @patch("climesync.util.get_field")
     def test_get_fields(self, mock_get_field):
         fields = [
-            ("strval",       "String value"),
+            ("strval",       "String value", ["str", "val"]),
             ("*optstrval",   "Optional string value"),
             ("?boolval",     "Bool value"),
             ("*?optboolval", "Optional bool value"),
             (":timeval",     "Time value"),
             ("*:opttimeval", "Optional time value"),
-            ("!listval",     "List value"),
+            ("!listval",     "List value", ["val1", "val2", "val3"]),
             ("*!optlistval", "Optional list value")
         ]
 


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->

fixes issue #113 
## Changes in this PR.

<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->
- [X] Cache project slugs, activity slugs, usernames, and user info on login
- [X] Use that data to validate fields where one or more slugs/usernames are entered and ask the user to try again
- [X] If there are no valid projects/activities/etc. to be entered, exit from the command
## Testing this PR.

<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->
1. Run `nosetests`
2. Run `climesync/climesync.py`, connect to the staging server, and log in as `admin`/`timesync-staging`
3. Run `gt` and attempt to enter invalid users, projects, and activities. See that you are given an error and asked to enter valid responses

@osuosl/devs
