### PR TITLE
Added option to view details of each time entry

### DIFF
--- a/climesync/commands.py
+++ b/climesync/commands.py
@@ -465,6 +465,17 @@ Examples:
         util.output_csv(times, "time", None)
         return []
 
+    # Logic for displaying time detail view
+    if interactive and "uuid" not in post_data:
+        detail_view = util.get_field("Display in detail view?", optional=True,
+                                     field_type="?")
+
+        if detail_view:
+            times.append("detail")
+    else:
+        times.append("detail")
+
+    # Attempt to query the server for times with filtering parameters
     return times
 
 

--- a/climesync/util.py
+++ b/climesync/util.py
@@ -579,18 +579,22 @@ def print_pretty_user(response):
 def print_pretty(response):
     """Attempts to print data returned by Pymesync nicely"""
 
-    data_type = determine_data_type(response)
-
-    if data_type == "time":
-        print_pretty_time(response)
-    elif data_type == "project":
-        print_pretty_project(response)
-    elif data_type == "activity":
-        print_pretty_activity(response)
-    elif data_type == "user":
-        print_pretty_user(response)
-    else:
+    if "detail" in response:
+        del response[response.index("detail")]
         print_json(response)
+    else:
+        data_type = determine_data_type(response)
+
+        if data_type == "time":
+            print_pretty_time(response)
+        elif data_type == "project":
+            print_pretty_project(response)
+        elif data_type == "activity":
+            print_pretty_activity(response)
+        elif data_type == "user":
+            print_pretty_user(response)
+        else:
+            print_json(response)
 
 
 def get_field(prompt, optional=False, field_type="", validator=None,

--- a/climesync/util.py
+++ b/climesync/util.py
@@ -535,6 +535,7 @@ def print_pretty_time(response):
             time_data["activities"] = time["activities"]
             time_data["duration"] = time["duration"]
             time_data["date_worked"] = time["date_worked"]
+            time_data["created_at"] = time["created_at"]
             time_data["issue_uri"] = time.setdefault("issue_uri", "")
             time_data["notes"] = time.setdefault("notes", "")
             time_data["uuid"] = time["uuid"]

--- a/climesync/util.py
+++ b/climesync/util.py
@@ -384,12 +384,9 @@ def print_pretty_time(response):
     """Abandon all hope ye who enter here"""
 
     if isinstance(response, dict):
-        time_data = {k: v for k, v in response.iteritems()
-                     if k in ["uuid", "duration", "project", "activity",
-                              "user", "date_worked"]}
+        response = [response] + ["detail"]
 
-        print_json(time_data)
-    elif isinstance(response, list):
+    if "detail" not in response:
         times = sorted(response, cmp=compare_date_worked)
         projects = list({time["project"][0] for time in times})
         activities = list({a for time in times for a in time["activities"]})
@@ -521,24 +518,48 @@ def print_pretty_time(response):
 
             print
     else:
-        print_json(response)
+        del response[response.index("detail")]
+
+        # Sort by date worked
+        times = sorted(response, cmp=compare_date_worked)
+
+        # Sort again by project slug
+        times = sorted(times, key=lambda t: t["project"])
+
+        times_data = []
+
+        for time in times:
+            time_data = OrderedDict()
+            time_data["user"] = time["user"]
+            time_data["project"] = time["project"]
+            time_data["activities"] = time["activities"]
+            time_data["duration"] = time["duration"]
+            time_data["date_worked"] = time["date_worked"]
+            time_data["issue_uri"] = time.setdefault("issue_uri", "")
+            time_data["notes"] = time.setdefault("notes", "")
+            time_data["uuid"] = time["uuid"]
+
+            times_data.append(time_data)
+
+        print_json(times_data)
 
 
 def print_pretty_project(response):
-    """"""
+    """Prints project data returned by Pymesync nicely"""
 
     if isinstance(response, dict):
         response = [response]
 
+    # Sort by project name
+    projects = sorted(response, key=lambda p: p["name"])
+
     projects_data = []
 
-    for project in response:
+    for project in projects:
         project_data = OrderedDict()
-        project_data = {k: v for k, v in project.iteritems()
-                        if k in ["name", "slugs", "users"]}
-
-        if "users" not in project_data:
-            project_data["users"] = {}
+        project_data["name"] = project["name"]
+        project_data["slugs"] = project["slugs"]
+        project_data["users"] = project.setdefault("users", {})
 
         projects_data.append(project_data)
 
@@ -546,55 +567,67 @@ def print_pretty_project(response):
 
 
 def print_pretty_activity(response):
-    """"""
+    """Prints activity data returned by Pymesync nicely"""
 
     if isinstance(response, dict):
         response = [response]
 
-    activity_data = []
+    # Sort by activity name
+    activities = sorted(response, key=lambda a: a["name"])
 
-    for activity in response:
-        activity_data.append({k: v for k, v in activity.iteritems()
-                              if k in ["name", "slug"]})
+    activities_data = []
 
-    print_json(activity_data)
+    for activity in activities:
+        activity_data = OrderedDict()
+        activity_data["name"] = activity["name"]
+        activity_data["slug"] = activity["slug"]
+
+        activities_data.append(activity_data)
+
+    print_json(activities_data)
 
 
 def print_pretty_user(response):
-    """"""
+    """Prints user data returned by Pymesync nicely"""
 
     if isinstance(response, dict):
         response = [response]
 
-    user_data = []
+    # Sort by username
+    users = sorted(response, key=lambda u: u["username"])
 
-    for user in response:
-        user_data.append({k: v for k, v in user.iteritems()
-                          if k in ["username", "display_name", "email",
-                                   "active"]})
+    # Sort again by active users
+    users = sorted(users, key=lambda u: u["active"], reverse=True)
 
-    print_json(user_data)
+    users_data = []
+
+    for user in users:
+        user_data = OrderedDict()
+        user_data["username"] = user["username"]
+        user_data["display_name"] = user["display_name"]
+        user_data["email"] = user.setdefault("email", "")
+        user_data["active"] = user["active"]
+
+        users_data.append(user_data)
+
+    print_json(users_data)
 
 
 def print_pretty(response):
     """Attempts to print data returned by Pymesync nicely"""
 
-    if "detail" in response:
-        del response[response.index("detail")]
-        print_json(response)
-    else:
-        data_type = determine_data_type(response)
+    data_type = determine_data_type(response)
 
-        if data_type == "time":
-            print_pretty_time(response)
-        elif data_type == "project":
-            print_pretty_project(response)
-        elif data_type == "activity":
-            print_pretty_activity(response)
-        elif data_type == "user":
-            print_pretty_user(response)
-        else:
-            print_json(response)
+    if data_type == "time":
+        print_pretty_time(response)
+    elif data_type == "project":
+        print_pretty_project(response)
+    elif data_type == "activity":
+        print_pretty_activity(response)
+    elif data_type == "user":
+        print_pretty_user(response)
+    else:
+        print_json(response)
 
 
 def get_field(prompt, optional=False, field_type="", validator=None,

--- a/testing/test_commands.py
+++ b/testing/test_commands.py
@@ -76,6 +76,8 @@ class CommandsTest(unittest.TestCase):
 
     @test_command(data=test_data.get_times_no_uuid_data)
     def test_get_times_no_uuid(self, expected, result):
+        print result
+        print expected
         assert result == expected
 
     @test_command(data=test_data.get_times_uuid_data)

--- a/testing/test_data.py
+++ b/testing/test_data.py
@@ -75,7 +75,7 @@ update_time_data = TestData(
 
 get_times_no_uuid_data = TestData(
         command=commands.get_times,
-        mocked_input=[None]*9,
+        mocked_input=[None]*9 + [True],
         cli_args="",
         expected_response=[{
                 "created_at": "2014-04-17",
@@ -118,7 +118,7 @@ get_times_no_uuid_data = TestData(
                 "user": "userthree",
                 "notes": "Worked on coding",
                 "issue_uri": "https://github.com/osuosl/timesync"
-        }],
+        }, "detail"],
         admin=False)
 
 get_times_uuid_data = TestData(
@@ -151,7 +151,7 @@ get_times_uuid_data = TestData(
             "user": "userone",
             "notes": "Worked on documentation.",
             "issue_uri": "https://github.com/osuosl/ganeti_webmgr"
-        }],
+        }, "detail"],
         admin=False)
 
 sum_times_data = TestData(

--- a/testing/test_scripting.py
+++ b/testing/test_scripting.py
@@ -65,6 +65,8 @@ class ScriptingTest(unittest.TestCase):
 
     @test_script(data=test_data.get_times_no_uuid_data)
     def test_get_times_no_uuid(self, expected, result):
+        print result
+        print expected
         assert result == expected
 
     @test_script(data=test_data.get_times_uuid_data)


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->

fixes issue #115 
## Changes in this PR.

<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->
- [X] In `gt`, the user is now asked if they want to display the times in detail (optional, defaults to the regular time overview display)
- [x] Use OrderedDicts to print information in an order that makes sense and is not implementation-dependent.
## Testing this PR.

<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->
1. Run `nosetests`
2. Run `climesync/climesync.py`, sign in, then run `gt`. When asked if you want to display in detail view, answer `y`
3. See that all the details of each time entry are printed onto the screen.

@osuosl/devs
