### PR TITLE
Added support for config files other than the default

### DIFF
--- a/climesync/climesync.py
+++ b/climesync/climesync.py
@@ -5,11 +5,13 @@
 Usage: climesync [options] [<command> [<args>... ]]
 
 Options:
-    -h             --help                 Print this dialog
-    -c <baseurl>   --connect=<baseurl>    TimeSync Server URL
-    -u <username>  --username=<username>  Username of user to authenticate as
-    -p <password>  --password=<password>  Password of user to authenticate as
-    -l             --ldap                 Authenticate using LDAP credentials
+    -h               --help                      Print this dialog
+    -c <baseurl>     --connect=<baseurl>         TimeSync Server URL
+    -u <username>    --username=<username>       Username of user
+    -p <password>    --password=<password>       Password of user
+    -l               --ldap                      Authenticate using LDAP
+    -f <config_file> --config-file=<config_file> Use a config file other than
+                                                 the default ~/.climesyncrc
 
 Commands:
 
@@ -164,18 +166,23 @@ def scripting_mode(command_name, argv):
 def main(argv=None, test=False):
     # Command line arguments
     args = docopt(__doc__, argv=argv, options_first=True)
+    print args
     url = args['-c']
     user = args['-u']
     password = args['-p']
     ldap = args['-l']
+    config_file = args['--config-file']
 
     command = args['<command>']
     argv = args['<args>']
 
     interactive = False if command else True
 
+    if not config_file:
+        config_file = "~/.climesyncrc"
+
     try:
-        config_obj = util.read_config()
+        config_obj = util.read_config(config_file)
 
         if config_obj.has_option("climesync", "autoupdate_config"):
             commands.autoupdate_config = \

--- a/climesync/climesync.py
+++ b/climesync/climesync.py
@@ -166,7 +166,6 @@ def scripting_mode(command_name, argv):
 def main(argv=None, test=False):
     # Command line arguments
     args = docopt(__doc__, argv=argv, options_first=True)
-    print args
     url = args['-c']
     user = args['-u']
     password = args['-p']

--- a/climesync/util.py
+++ b/climesync/util.py
@@ -11,6 +11,9 @@ from datetime import datetime
 from getpass import getpass
 
 
+config_file = None
+
+
 class UnicodeDictWriter:
     """
     Wrapper for csv.DictWriter that adds support for dictionaries with
@@ -88,6 +91,11 @@ def ts_error(*ts_objects):
 def create_config(path="~/.climesyncrc"):
     """Create the configuration file if it doesn't exist"""
 
+    global config_file
+
+    if config_file:
+        path = config_file
+
     realpath = os.path.expanduser(path)
 
     # Create the file if it doesn't exist then set its mode to 600 (Owner RW)
@@ -96,9 +104,16 @@ def create_config(path="~/.climesyncrc"):
 
     os.chmod(realpath, stat.S_IRUSR | stat.S_IWUSR)
 
+    config_file = path
+
 
 def read_config(path="~/.climesyncrc"):
     """Read the configuration file and return its contents"""
+
+    global config_file
+
+    if config_file:
+        path = config_file
 
     realpath = os.path.expanduser(path)
 
@@ -116,11 +131,18 @@ def read_config(path="~/.climesyncrc"):
             print "ERROR: Invalid configuration file!"
             return None
 
+    config_file = path
+
     return config
 
 
 def write_config(key, value, path="~/.climesyncrc"):
     """Write a value to the configuration file"""
+
+    global config_file
+
+    if config_file:
+        path = config_file
 
     realpath = os.path.expanduser(path)
 
@@ -152,6 +174,8 @@ def write_config(key, value, path="~/.climesyncrc"):
 
         # Write the config values
         config.write(f)
+
+    config_file = path
 
 
 def check_token_expiration(ts):

--- a/climesync/util.py
+++ b/climesync/util.py
@@ -869,7 +869,7 @@ def add_kv_pair(key, value, path="~/.climesyncrc"):
     else:
         print u"> {} = {}".format(key, value)
 
-    response = get_field("Add to the config file?",
+    response = get_field("Add to the config file ({})?".format(config_file),
                          optional=True, field_type="?")
 
     if response:


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->

fixes issue #117 
## Changes in this PR.

<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->
- [X] Added the command line option `-f` to select a config file other than the default `~/.climesyncrc`
## Testing this PR.

<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->
1. Run `nosetests`
2. Run `climesync/climesync.py -f testclimesyncrc` and enter in values for the TimeSync URL, username, and password
3. Exit Climesync and see that the file `testclimesyncrc` has been created with the values you entered.
4. Run `climesync/climesync.py -f testclimesyncrc` again and see that you've been logged in with the values inside `testclimesyncrc`.
5. Exit again and run `climesync/climesync.py` without specifying a config file. See that you've been logged in using the values in `~/.climesyncrc` instead of the values in `testclimesyncrc`

@osuosl/devs
