### PR TITLE
Catch keyboard interrupt for clean exit from commands and program

### DIFF
--- a/climesync/climesync.py
+++ b/climesync/climesync.py
@@ -209,7 +209,11 @@ def main(argv=None, test=False):
         scripting_mode(command, argv)
     else:
         util.print_json(response)
-        interactive_mode()
+
+        try:
+            interactive_mode()
+        except KeyboardInterrupt:
+            print "\nCaught keyboard interrupt. Exiting..."
 
 if __name__ == "__main__":
     main()

--- a/climesync/commands.py
+++ b/climesync/commands.py
@@ -56,6 +56,9 @@ class climesync_command():
                 except IndexError as e:
                     print e
                     return []
+                except KeyboardInterrupt:
+                    print "\nCaught keyboard interrupt. Exiting..."
+                    return []
 
         return wrapped_command
 


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->

fixes issue #120 
## Changes in this PR.

<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->
- [X] If `Ctrl+C` is pressed when entering input for a Climesync command, the user is brought back to the Climesync prompt
- [X] If `Ctrl+C` is pressed when on the Climesync prompt, Climesync exits cleanly (no traceback)
## Testing this PR.

<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->
1. Run `nosetests`
2. Run `climesync/climesync.py` and run the command `gt`
3. Press `Ctrl+C` to exit from the command, then `Ctrl+C` again to exit Climesync

@osuosl/devs
