### PR TITLE
'date_worked' now defaults to current date

### DIFF
--- a/climesync/commands.py
+++ b/climesync/commands.py
@@ -256,9 +256,12 @@ Examples:
     # The data to send to the server containing the new time information
     if post_data is None:
         post_data = util.get_fields([(":duration",   "Duration"),
-                                     ("~date_worked", "Date worked"),
+                                     ("*~date_worked", "Date worked"),
                                      ("project",     "Project slug",
-                                      user["project_slugs"])])
+                                      user["project_slugs"])],
+                                    current_object={
+                                        "date_worked": date.today()
+                                        })
 
         project_slug = post_data["project"]
 
@@ -280,7 +283,7 @@ Examples:
         post_data.update(post_data_cont)
 
     # Today's date
-    if post_data["date_worked"] == "today":
+    if "date_worked" not in post_data:
         post_data["date_worked"] = date.today().isoformat()
 
     # If activities was sent as a single item


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->

fixes issue #123 
## Changes in this PR.

<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->
- [X] Unless explicitly specified, `create_time` now uses the current date as the value for `date_worked`
## Testing this PR.

<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->
1. Run `nosetests`
2. Run `climesync/climesync.py` and sign in
3. Run `gt` and don't enter any input for `date_worked`
4. See that the time is submitted with the current date for as the `date_worked` field

@osuosl/devs
