### PR TITLE
Fixed adding users to projects with no users

### DIFF
--- a/climesync/commands.py
+++ b/climesync/commands.py
@@ -862,7 +862,7 @@ Examples:
 
     if "users" in post_data and not isinstance(post_data["users"], dict):
         users_list = post_data["users"]
-        current_users = current_project["users"]
+        current_users = current_project.setdefault("users", {})
         post_data["users"] = util.get_user_permissions(users_list,
                                                        current_users)
 


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #132 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Fixed a bug that was caused by directly accessing dictionary items instead of using `setdefault`

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Run `flake8 app testing`
2. Run `nosetests`
3. Sign in to the timesync-staging server and run `cp` to create a project, but don't add any users
4. Run `upu` and add a user to the project (note: the user might not show up in the output of `upu`)
5. Run `gp` to get the list of projects and see that the new user was added to the project

@osuosl/devs
